### PR TITLE
Add support for Project Explorer and make it default in Kotlin perspective

### DIFF
--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/model/kotlinModelUtils.kt
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/model/kotlinModelUtils.kt
@@ -23,14 +23,13 @@ import org.eclipse.core.runtime.jobs.IJobChangeEvent
 import org.eclipse.core.runtime.jobs.Job
 import org.eclipse.core.runtime.jobs.JobChangeAdapter
 import org.eclipse.jdt.core.IJavaProject
+import org.eclipse.jdt.core.JavaCore
 import org.jetbrains.kotlin.core.KotlinClasspathContainer
 import org.jetbrains.kotlin.core.utils.ProjectUtils
 
-fun unconfigureKotlinProject(javaProject: IJavaProject) {
-    val project = javaProject.getProject()
-    
+fun unconfigureKotlinProject(project: IProject) {
     unconfigureKotlinNature(project)
-    unconfigureKotlinRuntime(javaProject)
+    unconfigureKotlinRuntime(project)
     removeKotlinBinFolder(project)
 }
 
@@ -38,14 +37,16 @@ fun unconfigureKotlinNature(project: IProject) {
     if (KotlinNature.hasKotlinNature(project)) {
         val description = project.getDescription()
         val newNatures = description.getNatureIds().filter { it != KotlinNature.KOTLIN_NATURE }
-        
+
         description.setNatureIds(newNatures.toTypedArray())
         project.setDescription(description, null)
     }
 }
 
-fun unconfigureKotlinRuntime(javaProject: IJavaProject) {
-    if (ProjectUtils.hasKotlinRuntime(javaProject.getProject())) {
+fun unconfigureKotlinRuntime(project: IProject) {
+    val javaProject = project.getNature(JavaCore.NATURE_ID) as? IJavaProject
+
+    if (javaProject != null && ProjectUtils.hasKotlinRuntime(javaProject.getProject())) {
         val newEntries = javaProject.getRawClasspath().filterNot {
             ProjectUtils.equalsEntriesPaths(it, KotlinClasspathContainer.CONTAINER_ENTRY)
         }

--- a/kotlin-eclipse-ui/META-INF/MANIFEST.MF
+++ b/kotlin-eclipse-ui/META-INF/MANIFEST.MF
@@ -27,7 +27,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.equinox.p2.engine,
  org.eclipse.mylyn.commons.ui,
  org.eclipse.equinox.p2.director,
- org.eclipse.core.variables
+ org.eclipse.core.variables,
+ org.eclipse.ui.navigator;bundle-version="3.7.0"
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.core.expressions,
  org.eclipse.core.resources,

--- a/kotlin-eclipse-ui/plugin.xml
+++ b/kotlin-eclipse-ui/plugin.xml
@@ -323,28 +323,30 @@
                style="push">
          </command>
       </menuContribution>
-      <menuContribution
-            allPopups="false"
-            locationURI="popup:org.eclipse.jdt.ui.PackageExplorer">
-         <menu
-               label="Configure Kotlin">
-            <command
-                  commandId="org.jetbrains.kotlin.ui.commands.deconfiguration"
-                  label="Remove Kotlin Nature"
-                  style="push">
-               <visibleWhen
-                     checkEnabled="true">
-               </visibleWhen>
-            </command>
-            <command
-                  commandId="org.jetbrains.kotlin.ui.commands.configuration"
-                  label="Add Kotlin Nature"
-                  style="push">
-               <visibleWhen
-                     checkEnabled="true">
-               </visibleWhen>
-            </command>
-         </menu>
+      <menuContribution locationURI="popup:org.eclipse.ui.navigator.ProjectExplorer#PopupMenu">
+         <command
+               commandId="org.jetbrains.kotlin.ui.commands.j2k"
+               label="Convert Java to Kotlin"
+               style="push">
+         </command>
+      </menuContribution>
+      <menuContribution locationURI="popup:org.eclipse.ui.projectConfigure">
+         <command
+               commandId="org.jetbrains.kotlin.ui.commands.deconfiguration"
+               label="Remove Kotlin Nature"
+               style="push">
+            <visibleWhen
+                  checkEnabled="true">
+            </visibleWhen>
+         </command>
+         <command
+               commandId="org.jetbrains.kotlin.ui.commands.configuration"
+               label="Add Kotlin Nature"
+               style="push">
+            <visibleWhen
+                  checkEnabled="true">
+            </visibleWhen>
+         </command>
       </menuContribution>
       <menuContribution
             allPopups="false"
@@ -901,5 +903,70 @@
             </reference>
          </enabledWhen>
       </page>
+   </extension>
+   <extension point="org.eclipse.core.expressions.definitions">
+      <definition id="org.jetbrains.kotlin.newFileWizardEnablement">
+         <or>
+            <instanceof value="org.eclipse.jdt.core.IPackageFragment"/>
+            <instanceof value="org.eclipse.jdt.core.IPackageFragmentRoot"/>
+            <instanceof value="org.eclipse.jdt.core.ICompilationUnit"/>
+            <adapt type="org.eclipse.core.resources.IFile">
+               <or>
+                  <test property="org.eclipse.core.resources.extension" value="kt"/>
+                  <test property="org.eclipse.core.resources.extension" value="kts"/>
+               </or>
+            </adapt>
+            <adapt type="org.eclipse.core.resources.IProject">
+               <test property="org.eclipse.core.resources.projectNature" value="org.eclipse.jdt.core.javanature"/>
+            </adapt>
+         </or>
+      </definition>
+   </extension>
+   <extension point="org.eclipse.ui.navigator.navigatorContent">
+      <commonWizard
+              associatedExtensionId="org.eclipse.jdt.java.ui.javaContent"
+              menuGroupId="org.jetbrains.kotlin"
+              type="new"
+              wizardId="org.jetbrains.kotlin.wizard">
+         <enablement>
+            <reference definitionId="org.jetbrains.kotlin.newFileWizardEnablement"/>
+         </enablement>
+      </commonWizard>
+      <commonWizard
+              associatedExtensionId="org.eclipse.jdt.java.ui.javaContent"
+              menuGroupId="org.jetbrains.kotlin"
+              type="new"
+              wizardId="org.jetbrains.kotlin.classWizard">
+         <enablement>
+            <reference definitionId="org.jetbrains.kotlin.newFileWizardEnablement"/>
+         </enablement>
+      </commonWizard>
+      <commonWizard
+              associatedExtensionId="org.eclipse.jdt.java.ui.javaContent"
+              menuGroupId="org.jetbrains.kotlin"
+              type="new"
+              wizardId="org.jetbrains.kotlin.traitWizard">
+         <enablement>
+            <reference definitionId="org.jetbrains.kotlin.newFileWizardEnablement"/>
+         </enablement>
+      </commonWizard>
+      <commonWizard
+              associatedExtensionId="org.eclipse.jdt.java.ui.javaContent"
+              menuGroupId="org.jetbrains.kotlin"
+              type="new"
+              wizardId="org.jetbrains.kotlin.objectWizard">
+         <enablement>
+            <reference definitionId="org.jetbrains.kotlin.newFileWizardEnablement"/>
+         </enablement>
+      </commonWizard>
+      <commonWizard
+              associatedExtensionId="org.eclipse.jdt.java.ui.javaContent"
+              menuGroupId="org.jetbrains.kotlin"
+              type="new"
+              wizardId="org.jetbrains.kotlin.enumWizard">
+         <enablement>
+            <reference definitionId="org.jetbrains.kotlin.newFileWizardEnablement"/>
+         </enablement>
+      </commonWizard>
    </extension>
 </plugin>

--- a/kotlin-eclipse-ui/plugin.xml
+++ b/kotlin-eclipse-ui/plugin.xml
@@ -137,7 +137,7 @@
       <perspectiveExtension
             targetID="org.jetbrains.kotlin.perspective">
          <view
-               id="org.eclipse.jdt.ui.PackageExplorer"
+               id="org.eclipse.ui.navigator.ProjectExplorer"
                minimized="false"
                ratio="0.3"
                relationship="left"

--- a/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/commands/AbstractProjectActionHandler.kt
+++ b/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/commands/AbstractProjectActionHandler.kt
@@ -1,0 +1,42 @@
+package org.jetbrains.kotlin.ui.commands
+
+import org.eclipse.core.commands.AbstractHandler
+import org.eclipse.core.commands.ExecutionEvent
+import org.eclipse.core.resources.IProject
+import org.eclipse.jdt.core.IJavaProject
+import org.eclipse.jface.viewers.IStructuredSelection
+import org.eclipse.ui.ISources
+import org.eclipse.ui.handlers.HandlerUtil
+
+abstract class AbstractProjectActionHandler : AbstractHandler() {
+    protected abstract fun isEnabled(project: IProject): Boolean
+    protected abstract fun execute(project: IProject)
+
+    final override fun execute(event: ExecutionEvent): Any? {
+        val selection = HandlerUtil.getActiveMenuSelection(event)
+        val project = projectFromSelection(selection)
+
+        project?.let { execute(it) }
+
+        return null
+    }
+
+    final override fun setEnabled(evaluationContext: Any) {
+        val selection = HandlerUtil.getVariable(evaluationContext, ISources.ACTIVE_CURRENT_SELECTION_NAME)
+        val project = projectFromSelection(selection)
+
+        setBaseEnabled(project?.let { isEnabled(it) } ?: false)
+    }
+
+    private fun projectFromSelection(selection: Any?): IProject? =
+            (selection as? IStructuredSelection)
+                    ?.takeIf { it.size() == 1 }
+                    ?.firstElement
+                    ?.let {
+                        when (it) {
+                            is IProject -> it
+                            is IJavaProject -> it.project
+                            else -> null
+                        }
+                    }
+}

--- a/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/commands/ConfigureKotlinActionHandler.kt
+++ b/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/commands/ConfigureKotlinActionHandler.kt
@@ -16,38 +16,17 @@
 *******************************************************************************/
 package org.jetbrains.kotlin.ui.commands
 
-import org.eclipse.core.commands.AbstractHandler
-import org.eclipse.core.commands.ExecutionEvent
-import org.eclipse.jdt.core.IJavaProject
-import org.eclipse.jface.viewers.IStructuredSelection
-import org.eclipse.ui.ISources
-import org.jetbrains.kotlin.core.model.isConfigurationMissing
-import org.eclipse.ui.handlers.HandlerUtil
-import org.jetbrains.kotlin.wizards.NewUnitWizard
-import org.jetbrains.kotlin.ui.launch.KotlinRuntimeConfigurator
+import org.eclipse.core.resources.IProject
 import org.jetbrains.kotlin.core.model.KotlinNature
+import org.jetbrains.kotlin.core.model.isConfigurationMissing
+import org.jetbrains.kotlin.ui.launch.KotlinRuntimeConfigurator
 
-public class ConfigureKotlinActionHandler : AbstractHandler() {
-    override fun execute(event: ExecutionEvent): Any? {
-        val selection = HandlerUtil.getActiveMenuSelection(event)
-        val project = getFirstOrNullJavaProject(selection as IStructuredSelection)!!.getProject()
-        
+class ConfigureKotlinActionHandler : AbstractProjectActionHandler() {
+    override fun isEnabled(project: IProject): Boolean =
+            isConfigurationMissing(project)
+
+    override fun execute(project: IProject) {
         KotlinNature.addNature(project)
-        KotlinRuntimeConfigurator.suggestForProject(project);
-        
-        return null
-    }
-    
-    override fun setEnabled(evaluationContext: Any) {
-        val selection = HandlerUtil.getVariable(evaluationContext, ISources.ACTIVE_CURRENT_SELECTION_NAME)
-        if (selection is IStructuredSelection) {
-            val javaProject = getFirstOrNullJavaProject(selection)
-            if (javaProject != null) {
-                setBaseEnabled(isConfigurationMissing(javaProject.getProject()))
-                return
-            }
-        }
-        
-        setBaseEnabled(false)
+        KotlinRuntimeConfigurator.suggestForProject(project)
     }
 }

--- a/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/commands/DeconfigureKotlinActionHandler.kt
+++ b/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/commands/DeconfigureKotlinActionHandler.kt
@@ -1,35 +1,14 @@
 package org.jetbrains.kotlin.ui.commands
 
-import org.eclipse.core.commands.AbstractHandler
-import org.eclipse.core.commands.ExecutionEvent
-import org.eclipse.ui.handlers.HandlerUtil
-import org.eclipse.jdt.core.IJavaProject
-import org.eclipse.jface.viewers.IStructuredSelection
-import org.jetbrains.kotlin.core.model.unconfigureKotlinProject
+import org.eclipse.core.resources.IProject
 import org.jetbrains.kotlin.core.model.canBeDeconfigured
-import org.eclipse.ui.ISources
-import org.jetbrains.kotlin.core.model.KotlinNature
-import org.jetbrains.kotlin.core.utils.ProjectUtils
+import org.jetbrains.kotlin.core.model.unconfigureKotlinProject
 
-public class DeconfigureKotlinActionHandler : AbstractHandler() {
-	override fun execute(event: ExecutionEvent): Any? {
-		val selection = HandlerUtil.getActiveMenuSelection(event)
-		val project = getFirstOrNullJavaProject(selection as IStructuredSelection)
-		unconfigureKotlinProject(project!!)
-		
-		return null
-	}
-	
-	override fun setEnabled(evaluationContext: Any) {
-		val selection = HandlerUtil.getVariable(evaluationContext, ISources.ACTIVE_CURRENT_SELECTION_NAME)
-		if (selection is IStructuredSelection) {
-			val javaProject = getFirstOrNullJavaProject(selection)
-			if (javaProject != null) {
-				setBaseEnabled(canBeDeconfigured(javaProject.getProject()))
-				return
-			}
-		}
-		 
-		setBaseEnabled(false)
-	}
+class DeconfigureKotlinActionHandler : AbstractProjectActionHandler() {
+    override fun isEnabled(project: IProject): Boolean =
+            canBeDeconfigured(project)
+
+    override fun execute(project: IProject) {
+        unconfigureKotlinProject(project)
+    }
 }

--- a/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/commands/commandsUtils.kt
+++ b/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/commands/commandsUtils.kt
@@ -1,19 +1,13 @@
 package org.jetbrains.kotlin.ui.commands
 
-import org.eclipse.jface.viewers.IStructuredSelection
-import org.eclipse.jdt.core.IJavaProject
-import org.eclipse.jdt.internal.core.CompilationUnit
-import org.eclipse.ui.ide.undo.DeleteResourcesOperation
-import org.eclipse.core.resources.IProject
 import org.eclipse.core.resources.IFile
+import org.eclipse.core.resources.IProject
+import org.eclipse.jdt.internal.core.CompilationUnit
 import org.eclipse.ui.PlatformUI
 import org.eclipse.ui.ide.IDE
+import org.eclipse.ui.ide.undo.DeleteResourcesOperation
 
 data class ConvertedKotlinData(val file: IFile, val kotlinFileData: String)
-
-fun getFirstOrNullJavaProject(selection: IStructuredSelection): IJavaProject? {
-	return selection.toArray().firstOrNull() as? IJavaProject
-}
 
 fun getDeleteOperation(compilationUnits: Set<CompilationUnit>): DeleteResourcesOperation {
 	val resources = compilationUnits.map { it.getResource() }


### PR DESCRIPTION
Apart from Package Explorer, now also Project Explorer is supported.

The following actions were added to context menu in Project Explorer (similarly to Package Explorer):
* New Kotlin File/Class/Enum/Object/Interface
* Convert Java To Kotlin

The following actions were moved to *Configure* submenu, so that they are displayed in both Package and Project Explorer:
* Configure -> Add Kotlin nature
* Configure -> Remove Kotlin nature

Moreover in Kotlin perspective Package Explorer was replaced with Project Explorer.

![screenshot from 2018-07-12 17-36-30](https://user-images.githubusercontent.com/11313923/42643795-5381291a-85fa-11e8-89db-5ed5e49c498c.png)
![screenshot from 2018-07-12 13-29-08](https://user-images.githubusercontent.com/11313923/42643793-52431e96-85fa-11e8-88f4-e78bb562a661.png)
